### PR TITLE
Fix/add test retry

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     env:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -42,7 +42,6 @@ jobs:
   
   integration-tests:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       max-parallel: 2
       matrix:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
+      max-parallel: 1
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     env:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install smartsheet-python-sdk
 ## Getting Started
 To get started with the Smartsheet Python SDK:
 
-1.  Set **SMARTSHEET_ACCESS_TOKEN** in your environment, using your Smartsheet API key. Find out more about [Authentication and Access Tokens](https://smartsheet.redoc.ly/#section/API-Basics/Raw-Token-Requests) in the Smartsheet API Documentation. You can generate an access token in Smartsheet UI under Account > Personal Settings > API Access.
+1.  Set **SMARTSHEET_ACCESS_TOKEN** in your environment, using your Smartsheet API key. Find out more about [Authentication and Access Tokens](https://smartsheet.redoc.ly/#section/API-Basics/Authentication-and-Access-Tokens) in the Smartsheet API Documentation. You can generate an access token in Smartsheet UI under Account > Personal Settings > API Access.
 
 2.  Install the Smartsheet Python SDK (see [installation instructions](###installation) above)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [tool:pytest]
-addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --retries 2
+addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --reruns 2
 log_cli = true
 log_level = NOTSET
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [tool:pytest]
-addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --reruns 2
+addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --reruns 2  --reruns-delay 3
 log_cli = true
 log_level = NOTSET
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [tool:pytest]
-addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native
+addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --retries 2
 log_cli = true
 log_level = NOTSET
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
         'test': [
             'coverage',
             'coveralls',
-            'pytest'
+            'pytest',
+            'pytest-retry'
         ],
         'develop': [
             'coverage',

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
             'pytest-instafail'
         ]
     },
-    tests_require=['pytest', 'pytest-retry'],
+    tests_require=['pytest', 'pytest-rerunfailures'],
     cmdclass={
         'test': PyTest
     }

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,7 @@ setup(
         'test': [
             'coverage',
             'coveralls',
-            'pytest',
-            'pytest-retry'
+            'pytest'
         ],
         'develop': [
             'coverage',
@@ -87,7 +86,7 @@ setup(
             'pytest-instafail'
         ]
     },
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pytest-retry'],
     cmdclass={
         'test': PyTest
     }


### PR DESCRIPTION
- Don't allow integration tests to continue on failure
- Add rerun to accommodate for flaky tests
- Set integration tests to only run 2 in parallel, to avoid hitting the API rate limit as much.