### PR TITLE
chore: set log level to error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [tool:pytest]
 addopts = -ra --color=yes --showlocals --verbose --ignore=docs --ignore=examples --tb=native --reruns 2  --reruns-delay 3
 log_cli = true
-log_level = NOTSET
+log_level = ERROR
 
 [coverage:run]
 omit =


### PR DESCRIPTION
- change test output level to ERROR to reduce log volume