### PR TITLE
chore: remove integration tests from test pipeline

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -62,42 +62,9 @@ jobs:
           path-to-lcov: "coverage.lcov"          
           parallel: true
 
-  integration-tests:
-    needs: lint
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 2
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-    env:
-      SMARTSHEET_ACCESS_TOKEN: ${{ secrets.INTEGRATION_TEST_SMARTSHEET_ACCESS_TOKEN }}
-      SMARTSHEET_FIXTURE_USERS: ${{ secrets.SMARTSHEET_FIXTURE_USERS}}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install certifi enum34 requests six python-dateutil coverage coveralls[yaml] pytest pytest-instafail requests-toolbelt
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Run integration tests
-        run: |
-          coverage run --source=smartsheet setup.py test -a tests/integration/
-          coverage lcov
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-${{ matrix.python-version }}
-          path-to-lcov: "coverage.lcov"
-          parallel: true
-
   build-packages-test:
     runs-on: ubuntu-latest
-    needs: [mock-api-test, integration-tests]
+    needs: [mock-api-test]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Integration tests are not running reliably. Removing them from the pipeline until we can run them in an idempotent manner.