### PR TITLE
Avoid DeprecationWarning of collections.abc if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2023-03-31
+
+### Updated
+
+- Changing import order to better support later versions of python
+
 ## [3.0.0] - 2022-12-06
 
 ### Updated

--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -1,4 +1,4 @@
-# pylint: disable=C0111,R0902,R0913,W4904,W0706
+# pylint: disable=C0111,R0902,R0913,W4904,W0706,W0237
 # Smartsheet Python SDK.
 #
 # Copyright 2016 Smartsheet.com, Inc.

--- a/smartsheet/types.py
+++ b/smartsheet/types.py
@@ -16,11 +16,11 @@
 # under the License.
 
 try:
-    # For Python versions 2.7 and 3.3 to 3.9, import from collections
-    from collections import MutableSequence
-except ImportError:
     # For Python version >= 3.10 import from collections.abc
     from collections.abc import MutableSequence
+except ImportError:
+    # For Python versions 2.7 and 3.3 to 3.9, import from collections
+    from collections import MutableSequence
 
 import importlib
 import json


### PR DESCRIPTION
Why not the other way around, right?

![](https://user-images.githubusercontent.com/25005517/209167156-090e7d34-71f6-4623-bff3-6af9eb10c231.png)
