### PR TITLE
fix(session): updating default retryable methods reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2023-05-15
+
+### Updated
+
+- Update urllib3 default retryable methods reference
+
 ## [3.0.1] - 2023-03-31
 
 ### Updated

--- a/smartsheet/session.py
+++ b/smartsheet/session.py
@@ -53,7 +53,7 @@ def pinned_session(pool_maxsize=8):
         pool_connections=4,
         pool_maxsize=pool_maxsize,
         max_retries=Retry(
-            total=1, method_whitelist=Retry.DEFAULT_ALLOWED_METHODS.union(["POST"])
+            total=1, allowed_methods=Retry.DEFAULT_ALLOWED_METHODS.union(["POST"])
         ),
     )
 

--- a/smartsheet/session.py
+++ b/smartsheet/session.py
@@ -53,7 +53,7 @@ def pinned_session(pool_maxsize=8):
         pool_connections=4,
         pool_maxsize=pool_maxsize,
         max_retries=Retry(
-            total=1, method_whitelist=Retry.DEFAULT_METHOD_WHITELIST.union(["POST"])
+            total=1, method_whitelist=Retry.DEFAULT_ALLOWED_METHODS.union(["POST"])
         ),
     )
 


### PR DESCRIPTION
## What

Updating the references to urllib3's default retryable methods

## Why
The param for the `Retry` class has been renamed to `allowed_methods` and the set of methods has been renamed from `DEFAULT_METHOD_WHITELIST` to `DEFAULT_METHODS_ALLOWED`. These old names have been deprecated since 1.26.0 and removed in 2.0.0 of urllib3

Fixes #32 