### PR TITLE
import models in __init__

### DIFF
--- a/smartsheet/__init__.py
+++ b/smartsheet/__init__.py
@@ -33,3 +33,5 @@ except ImportError:
 
 from .smartsheet import (AbstractUserCalcBackoff, Smartsheet,  # NOQA
                          fresh_operation)
+
+from . import models


### PR DESCRIPTION
I'm using pyright for linting and am getting errors like:
```
"models" is not a known member of module "smartsheet"
```

This PR fixes that by explicitly importing models in the smartsheet module