### PR TITLE
Prevent error from being raised when content type header is missing

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "line-length": false,
   "no-duplicate-heading": {
-    "siblings-only": true
+    "siblings_only": true
   }
 }

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,5 @@
 {
   "line-length": false,
-  "no-duplicate-heading",
-    siblings-only: true
+  "no-duplicate-heading":
+    "siblings-only": true
 }

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,5 @@
 {
   "line-length": false,
-  "no-duplicate-header": false
+  "no-duplicate-heading",
+    siblings-only: true
 }

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,6 @@
 {
   "line-length": false,
-  "no-duplicate-heading":
+  "no-duplicate-heading": {
     "siblings-only": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- fix KeyError: 'content-type': https://github.com/smartsheet/smartsheet-python-sdk/issues/43
+- fix for [issue 43](https://github.com/smartsheet/smartsheet-python-sdk/issues/43) KeyError: 'content-type'
 
 ## [3.0.2] - 2023-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2024-07-17
+
+### Fixed
+
+- fix KeyError: 'content-type': https://github.com/smartsheet/smartsheet-python-sdk/issues/43
+
 ## [3.0.2] - 2023-05-15
 
 ### Updated

--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -279,16 +279,16 @@ class Smartsheet:
             response.request.url,
         )
         if response.request.body is not None:
-            body_dumps = f'"<< {response.request.headers["Content-Type"]} content type suppressed >>"'
+            body_dumps = f'"<< {response.request.headers.get("Content-Type")} content type suppressed >>"'
             if is_multipart(response.request):
                 body_dumps = '"<< multipart body suppressed >>"'
-            elif "application/json" in response.request.headers["Content-Type"]:
+            elif "application/json" in response.request.headers.get("Content-Type"):
                 body = response.request.body.decode("utf8")
                 body_dumps = json.dumps(json.loads(body), sort_keys=True)
             self._log.debug('{"requestBody": %s}', body_dumps)
         # response
-        content_dumps = f'"<< {response.headers["Content-Type"]} content type suppressed >>"'
-        if "application/json" in response.headers["Content-Type"]:
+        content_dumps = f'"<< {response.headers.get("Content-Type")} content type suppressed >>"'
+        if "application/json" in response.headers.get("Content-Type"):
             content = response.content.decode("utf8")
             content_dumps = json.dumps(json.loads(content), sort_keys=True)
         if 200 <= response.status_code <= 299:

--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -282,13 +282,13 @@ class Smartsheet:
             body_dumps = f'"<< {response.request.headers.get("Content-Type")} content type suppressed >>"'
             if is_multipart(response.request):
                 body_dumps = '"<< multipart body suppressed >>"'
-            elif "application/json" in response.request.headers.get("Content-Type"):
+            elif response.request.headers.get("Content-Type") is not None and "application/json" in response.request.headers.get("Content-Type"):
                 body = response.request.body.decode("utf8")
                 body_dumps = json.dumps(json.loads(body), sort_keys=True)
             self._log.debug('{"requestBody": %s}', body_dumps)
         # response
         content_dumps = f'"<< {response.headers.get("Content-Type")} content type suppressed >>"'
-        if "application/json" in response.headers.get("Content-Type"):
+        if response.request.headers.get("Content-Type") is not None and "application/json" in response.headers.get("Content-Type"):
             content = response.content.decode("utf8")
             content_dumps = json.dumps(json.loads(content), sort_keys=True)
         if 200 <= response.status_code <= 299:


### PR DESCRIPTION
Sometimes when logging a request information the Content-Type header isn't preset resulting in the issue: https://github.com/smartsheet/smartsheet-python-sdk/issues/43

This PR uses `.get("Content-Type")` instead of `["Content-Type"]` so that an error isn't raised when the header isn't present.