### PR TITLE
to parameter for events under Event Reporting added

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -115,6 +115,13 @@ start consuming events. The `since` parameter can be set with a datetime value t
 (e.g. 2010-01-01T00:00:00Z) or as UNIX epoch (in which case the `numeric_dates` parameter must also be set to `True`.
 By default the `numeric_dates` parameter is set to `False`).
 
+The sample utilizes the `smartsheet_client.Events.list_events` method to request a list of events up to a certain 
+point in the stream. The `to` parameter specifies the endpoint in time (i.e., event occurrence datetime) in the stream 
+up to which events should be retrieved. This `to` parameter can be assigned a datetime value formatted either as 
+ISO 8601 (e.g., 2020-12-31T23:59:59Z) or as UNIX epoch time, in which case the numeric_dates parameter must be set to True. 
+If not specified, the `numeric_dates` parameter defaults to `False`, assuming the datetime is in ISO 8601 format. 
+This allows for precise control over the range of events to be fetched, facilitating efficient data retrieval and processing.
+
 To consume the next list of events after the initial list of events is returned, set the `stream_position` parameter
 with the `next_stream_position` property obtained from the previous request and don't set the `since` parameter with
 any values. This is because when using the `list_events` method, either the `since` parameter or the `stream_position`

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -115,11 +115,11 @@ start consuming events. The `since` parameter can be set with a datetime value t
 (e.g. 2010-01-01T00:00:00Z) or as UNIX epoch (in which case the `numeric_dates` parameter must also be set to `True`.
 By default the `numeric_dates` parameter is set to `False`).
 
-The sample utilizes the `smartsheet_client.Events.list_events` method to request a list of events up to a certain 
-point in the stream. The `to` parameter specifies the endpoint in time (i.e., event occurrence datetime) in the stream 
-up to which events should be retrieved. This `to` parameter can be assigned a datetime value formatted either as 
-ISO 8601 (e.g., 2020-12-31T23:59:59Z) or as UNIX epoch time, in which case the numeric_dates parameter must be set to True. 
-If not specified, the `numeric_dates` parameter defaults to `False`, assuming the datetime is in ISO 8601 format. 
+The sample utilizes the `smartsheet_client.Events.list_events` method to request a list of events up to a certain
+point in the stream. The `to` parameter specifies the endpoint in time (i.e., event occurrence datetime) in the stream
+up to which events should be retrieved. This `to` parameter can be assigned a datetime value formatted either as
+ISO 8601 (e.g., 2020-12-31T23:59:59Z) or as UNIX epoch time, in which case the numeric_dates parameter must be set to True.
+If not specified, the `numeric_dates` parameter defaults to `False`, assuming the datetime is in ISO 8601 format.
 This allows for precise control over the range of events to be fetched, facilitating efficient data retrieval and processing.
 
 To consume the next list of events after the initial list of events is returned, set the `stream_position` parameter

--- a/pylintrc
+++ b/pylintrc
@@ -9,3 +9,6 @@ output-format=colorized
 
 [BASIC]
 include-naming-hint=yes
+
+[FORMAT]
+max-line-length=160

--- a/smartsheet/events.py
+++ b/smartsheet/events.py
@@ -30,13 +30,19 @@ class Events:
         self._log = logging.getLogger(__name__)
 
     def list_events(
-        self, since=None, stream_position=None, max_count=None, numeric_dates=None
+        self, since=None, to=None, stream_position=None, max_count=None, numeric_dates=None
     ):
         """Get the list of all Events.
 
         Args:
             since (str or long): Starting time for events to return.
                 You must pass in a value for either since or streamPosition and never both.
+            to (str or long): Ending time for events to return. 
+                This parameter specifies the endpoint in time for the events to be fetched. 
+                Similar to the `since` parameter, `to` can be passed in either as a datetime string in 
+                ISO 8601 format or as a UNIX epoch time in milliseconds. This allows for defining a 
+                precise time range for the events query. Note that `to` is optional and can be used in 
+                conjunction with `since` to specify both the start and end times for the event retrieval window.
             stream_position (str): Indicates next set of events to return.
                 Use value of nextStreamPosition returned from the previous call.
                 You must pass in a value for either since or streamPosition and never both.
@@ -53,9 +59,14 @@ class Events:
         _op["method"] = "GET"
         _op["path"] = "/events"
         if isinstance(since, datetime):
-            _op["query_params"]["since"] = since  # .isoformat()
+            _op["query_params"]["since"] = since.isoformat()
         else:
             _op["query_params"]["since"] = since
+        
+        if isinstance(to, datetime):
+            _op["query_params"]["to"] = to.isoformat()
+        else:
+            _op["query_params"]["to"] = to
         _op["query_params"]["streamPosition"] = stream_position
         _op["query_params"]["maxCount"] = max_count
         _op["query_params"]["numericDates"] = numeric_dates

--- a/smartsheet/events.py
+++ b/smartsheet/events.py
@@ -30,18 +30,18 @@ class Events:
         self._log = logging.getLogger(__name__)
 
     def list_events(
-        self, since=None, to=None, stream_position=None, max_count=None, numeric_dates=None
+        self, since=None, to=None, stream_position=None, max_count=None, numeric_dates=None # pylint: disable=invalid-name
     ):
         """Get the list of all Events.
 
         Args:
             since (str or long): Starting time for events to return.
                 You must pass in a value for either since or streamPosition and never both.
-            to (str or long): Ending time for events to return. 
-                This parameter specifies the endpoint in time for the events to be fetched. 
-                Similar to the `since` parameter, `to` can be passed in either as a datetime string in 
-                ISO 8601 format or as a UNIX epoch time in milliseconds. This allows for defining a 
-                precise time range for the events query. Note that `to` is optional and can be used in 
+            to (str or long): Ending time for events to return.
+                This parameter specifies the endpoint in time for the events to be fetched.
+                Similar to the `since` parameter, `to` can be passed in either as a datetime string in
+                ISO 8601 format or as a UNIX epoch time in milliseconds. This allows for defining a
+                precise time range for the events query. Note that `to` is optional and can be used in
                 conjunction with `since` to specify both the start and end times for the event retrieval window.
             stream_position (str): Indicates next set of events to return.
                 Use value of nextStreamPosition returned from the previous call.
@@ -62,7 +62,7 @@ class Events:
             _op["query_params"]["since"] = since.isoformat()
         else:
             _op["query_params"]["since"] = since
-        
+
         if isinstance(to, datetime):
             _op["query_params"]["to"] = to.isoformat()
         else:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,7 +23,7 @@ Some tests carry requirements. We're testing the real service here, not just usi
 The test suite expects these environment variables to be present:
 
 ```shell
-    export SMARTSHEET_ACCESS_TOKEN="Bearer 3JRm067VUxw1u84MRMHEguCYdn5m8nvFpVhWb"
+    export SMARTSHEET_ACCESS_TOKEN="SSSSSSSSSSSSSSSSSSSSSSSSSS"
     export LOG_CFG="debug" # optional
     export SMARTSHEET_FIXTURE_USERS='{"admin":{"id":9999999999999999},"larry":{"id":0000000000000000},"curly":{"id":1111111111111111},"moe":{"id":2222222222222222}}'
 ```

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -23,7 +23,7 @@ Some tests carry requirements. We're testing the real service here, not just usi
 The test suite expects these environment variables to be present:
 
 ```shell
-    export SMARTSHEET_ACCESS_TOKEN="SSSSSSSSSSSSSSSSSSSSSSSSSS"
+    export SMARTSHEET_ACCESS_TOKEN="Bearer 3JRm067VUxw1u84MRMHEguCYdn5m8nvFpVhWb"
     export LOG_CFG="debug" # optional
     export SMARTSHEET_FIXTURE_USERS='{"admin":{"id":9999999999999999},"larry":{"id":0000000000000000},"curly":{"id":1111111111111111},"moe":{"id":2222222222222222}}'
 ```

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -3,7 +3,6 @@ import six
 from datetime import datetime, timedelta
 import smartsheet
 
-
 @pytest.mark.usefixtures("smart_setup")
 class TestEvents:
 
@@ -11,7 +10,9 @@ class TestEvents:
         smart = smart_setup['smart']
 
         last_hour = datetime.now() - timedelta(hours=1)
-        events_list = smart.Events.list_events(since=last_hour.isoformat(), max_count=10)
+        current_time = datetime.now()
+
+        events_list = smart.Events.list_events(since=last_hour.isoformat(), to=current_time.isoformat(), max_count=10)
         assert isinstance(events_list, smart.models.EventResult)
         assert len(events_list.data) <= 10
         for event in events_list.data:


### PR DESCRIPTION
There's been an update to the API owned by Event Reporting.

A `to` param has been introduced as end timestamp for fetching events. 