### PR TITLE
Add check for dict in serialize function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.4] - 2024-07-29
+
+### Changed
+
+- Changed `serialize` function to also handle dicts - this allows the Event Reporting API to 
+  return the `additionalDetails` object correctly
+
 ## [3.0.3] - 2024-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Changed `serialize` function to also handle dicts - this allows the Event Reporting API to 
+- Changed `serialize` function to also handle dicts - this allows the Event Reporting API to
   return the `additionalDetails` object correctly
+
+### Added
+
+- `to` parameter added for Event Reporting - allows setting an end timestamp for filtering for
+  events
 
 ## [3.0.3] - 2024-07-17
 

--- a/smartsheet/util.py
+++ b/smartsheet/util.py
@@ -112,6 +112,14 @@ def serialize(obj):
                 serialized = serialize(item)
                 if not hasattr(serialized, "is_explicit_null"):
                     retval.append(serialized)
+
+    elif isinstance(obj, dict):
+        retval = {}
+        for key, value in obj.items():
+            serialized_value = serialize(value)
+            if not hasattr(serialized_value, "is_explicit_null"):
+                retval[key] = serialized_value
+
     else:
         retval = {}
         prop_list = get_child_properties(obj)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import smartsheet
 
 
+
 @pytest.mark.usefixtures("smart_setup")
 class TestEvents:
 
@@ -24,6 +25,8 @@ class TestEvents:
             assert event.request_user_id is not None
             # assert event.access_token_name is not None
             assert event.source.value is not None
+            if event.additional_details is not None:
+                assert isinstance(event.additional_details, dict)
 
         while events_list.more_available:
             events_list = smart.Events.list_events(stream_position=events_list.next_stream_position, max_count=10,
@@ -40,6 +43,8 @@ class TestEvents:
                 assert event.request_user_id is not None
                 # assert event.access_token_name is not None
                 assert event.source.value is not None
+                if event.additional_details is not None:
+                    assert isinstance(event.additional_details, dict)
 
     def test_invalid_params(self, smart_setup):
         smart = smart_setup['smart']

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 import smartsheet
 
 
-
 @pytest.mark.usefixtures("smart_setup")
 class TestEvents:
 


### PR DESCRIPTION
**Description:**

This pull request introduces a change to the `serialize` function in `smartsheet/util.py` to ensure that the `additionalDetails` property is correctly serialized when present in the response for the Event Reporting API.

**Changes:**

1. **Code Changes:**
   - Added an `elif isinstance(obj, dict)` statement in the `serialize` function to handle dictionary objects. This ensures that properties like `additionalDetails`, which are dictionaries with an unknown number/type of key:value pairs, are correctly serialized and included in the output.

2. **Test Changes:**
   - Updated the integration test `test_list_events` in `tests/integration/test_events.py` to include a check for the `additionalDetails` field. This test now verifies that when `additionalDetails` is present, it is correctly populated and is of type `dict`.

**Reason for Change:**

The `additionalDetails` property was missing when querying Event Reporting. By adding the `elif isinstance(obj, dict)` statement, we ensure that dictionary properties are handled properly during the serialization process, preserving the integrity of the API response.

**Testing:**

- Ran a small script to query the Event Reporting API and verify that the `additionalDetails` field is correctly serialized and populated when present in the response (sample outputs below).
- Ran all mock and integration tests locally
  - Before this change the test results were: 8 failed, 340 passed, 10 skipped, 1 xpassed, 89 warnings, 16 rerun
  - After this change (and adding the additional test), the test results were identical - none of the failures appear to be related to Event Reporting or serialization
  - It should be noted that a number of the serialization mock tests were skipped due to the mock API not being updated, and also there doesn't appear to be any mock tests for Events.

**Sample output:**

Without handling dicts during serialization:
```
{
    "action": "AUTHORIZE",
    "additionalDetails": {},
    "eventId": "REDACTED",
    "eventTimestamp": "2024-03-20T16:03:17+00:00Z",
    "objectId": "REDACTED",
    "objectType": "ACCESS_TOKEN",
    "requestUserId": "REDACTED",
    "source": "UNKNOWN",
    "userId": "REDACTED"
}
```

With change to serialize dicts:
```
{
    "action": "AUTHORIZE",
    "additionalDetails": {
        "tokenExpirationTimestamp": "2024-03-27T16:03:17Z",
        "emailAddress": "REDACTED",
        "firstLoginTimestamp": "2018-09-18T20:07:03Z",
        "appName": "REDACTED",
        "accessScopes": "ADMIN_USERS,CREATE_SHEETS,ADMIN_WEBHOOKS,READ_USERS,WRITE_SHEETS,ADMIN_SHEETS,READ_SHEETS",
        "tokenDisplayValue": "REDACTED",
        "appClientId": "REDACTED"
    },
    "eventId": "REDACTED",
    "eventTimestamp": "2024-03-20T16:03:17+00:00Z",
    "objectId": "REDACTED",
    "objectType": "ACCESS_TOKEN",
    "requestUserId": "REDACTED",
    "source": "UNKNOWN",
    "userId": "REDACTED"
}
```

** Note: **
I believe this supersedes Salman's PR [here](https://github.com/smartsheet/smartsheet-python-sdk/pull/47) - `additionalDetails` is still empty when querying when I tested with his change.