### PR TITLE
Add `level` to docstrings

### DIFF
--- a/smartsheet/cells.py
+++ b/smartsheet/cells.py
@@ -55,6 +55,7 @@ class Cells:
             page (int): Which page to return.
             include_all (bool): If true, include all results
                 (i.e. do not paginate).
+            level (int): compatibility level
 
         Returns:
             IndexResult

--- a/smartsheet/reports.py
+++ b/smartsheet/reports.py
@@ -69,6 +69,7 @@ class Reports:
             include (list[str]): A comma-separated list of
                 optional elements to include in the response. Valid list values:
                 attachments, discussions, format, objectValue, scope, source, sourceSheets.
+            level (int): compatibility level
 
         Returns:
             Report

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -534,6 +534,7 @@ class Sheets:
             page (int): Which page to return.
             if_version_after (int): only fetch Sheet if more recent version
                 available.
+            level (int): compatibility level
             rows_modified_since: Date should be in ISO-8601 format, for example, rowsModifiedSince=2020-01-30T13:25:32-07:00.
             filter_id (int): Applies the given filter (if accessible by the calling user)
                 and marks the affected rows as "filteredOut": true
@@ -1620,6 +1621,7 @@ class Sheets:
         Args:
             sheet_id (int): Sheet ID
             sort_specifier_obj (SortSpecifier): SortSpecifier object
+            level (int): compatibility level
 
         Returns:
             Sheet


### PR DESCRIPTION
I noticed `level` is missing from a few docstrings, so I copied one of the existing docstrings and added that to each location it was missing.

There are currently two different `level` descriptions in docstrings, and I've selected the less verbose option here because it seemed to me to be the better match for the level of detail in the docstrings.