### PR TITLE
Disable pylint rule: too-many-positional-arguments

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,7 @@
 jobs=0
 
 [MESSAGES CONTROL]
-disable=missing-docstring,too-many-arguments,locally-disabled,too-few-public-methods,too-many-public-methods,duplicate-code,too-many-instance-attributes,too-many-lines,no-else-return,unused-private-member,cyclic-import,unused-import,import-outside-toplevel,consider-using-with
+disable=missing-docstring,too-many-arguments,too-many-positional-arguments,locally-disabled,too-few-public-methods,too-many-public-methods,duplicate-code,too-many-instance-attributes,too-many-lines,no-else-return,unused-private-member,cyclic-import,unused-import,import-outside-toplevel,consider-using-with
 
 [REPORTS]
 output-format=colorized


### PR DESCRIPTION
A new pylint rule, [too-many-positional-arguments](https://pylint.readthedocs.io/en/v3.3.3/user_guide/messages/refactor/too-many-positional-arguments.html), was recently introduced that is incompatible with the design of this SDK.