### PR TITLE
fix: pipeline

### DIFF
--- a/.github/workflows/publish-distribution.yaml
+++ b/.github/workflows/publish-distribution.yaml
@@ -16,12 +16,12 @@ jobs:
           python-version: '3.10'
       - name: Install build packages
         run: |
-          pip install enum34 requests six python-dateutil setuptools-scm gitchangelog mako wheel twine sphinx sphinx_rtd_theme
+          pip install enum34 requests six python-dateutil setuptools-scm==7.1.0 gitchangelog mako wheel twine sphinx sphinx_rtd_theme
       - name: Build distribution
         run: |
           python setup.py sdist bdist_wheel
       - name: Archive distribution artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distribution
           path: dist

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.10'
       - name: Install build packages
         run: |
-          pip install enum34 requests six python-dateutil setuptools-scm gitchangelog mako wheel twine sphinx sphinx_rtd_theme
+          pip install enum34 requests six python-dateutil setuptools-scm==7.1.0 gitchangelog mako wheel twine sphinx sphinx_rtd_theme
       - name: Generate documentation
         run: |
           sphinx-apidoc -o docs-source smartsheet

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -24,10 +24,19 @@ jobs:
 
   mock-api-test:
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        include:
+          - python-version: "3.7"
+            os: ubuntu-22.04
+          - python-version: "3.8"
+            os: ubuntu-latest
+          - python-version: "3.9"
+            os: ubuntu-latest
+          - python-version: "3.10"
+            os: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -35,6 +44,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -66,18 +76,16 @@ jobs:
     needs: [mock-api-test]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install build packages
         run: |
-          pip install enum34 requests six python-dateutil setuptools-scm gitchangelog mako wheel twine 
+          pip install enum34 requests six python-dateutil setuptools-scm==7.1.0 gitchangelog mako wheel twine 
       - name: Build distribution
         run: |
           python setup.py sdist bdist_wheel
       - name: Archive distribution artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distribution
           path: dist
@@ -96,7 +104,7 @@ jobs:
       - name: Generate HTML
         run: sphinx-build -b html -d docs-source/_build/doctrees docs-source/. docs-source/_build/html
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-docs
           path: docs/build/html/

--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,7 @@
 jobs=0
 
 [MESSAGES CONTROL]
-disable=missing-docstring,too-many-arguments,locally-disabled,too-few-public-methods,too-many-public-methods,duplicate-code,too-many-instance-attributes,too-many-lines,no-else-return,unused-private-member,cyclic-import,unused-import,import-outside-toplevel,consider-using-with
+disable=missing-docstring,too-many-arguments,too-many-positional-arguments,locally-disabled,too-few-public-methods,too-many-public-methods,duplicate-code,too-many-instance-attributes,too-many-lines,no-else-return,unused-private-member,cyclic-import,unused-import,import-outside-toplevel,consider-using-with
 
 [REPORTS]
 output-format=colorized

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     use_scm_version={
         'write_to': 'smartsheet/version.py'
     },
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm==7.0.1'],
     install_requires=REQUIRES,
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## Changes to pipeline steps 

### test-build :: linting
   - Turn off `too-many-positional-arguments` in linting

### test-build :: mock-api-test
- Ubuntu v24 doesn't come with python 3.7, so need to set the ubuntu version for the 3.7 tests
- `setuptools-scm` has issues so has been pinned to the latest working version 7.1.0

### test-build :: build-packages-test
- Github actions `upload-artifact@v3` deprecated so upgraded to v4
- Same issue with `setuptools-scm`, pinned install to 7.1.0
- Remove undefined/unused `python-version` 

### publish-distribution :: build-publish
- `setuptools-scm` has issues so has been pinned to the latest working version 7.1.0

### publish-documentation :: build-documentation
- `setuptools-scm` has issues so has been pinned to the latest working version 7.1.0
