### PR TITLE
pipeline update v2

### DIFF
--- a/.github/workflows/publish-distribution.yaml
+++ b/.github/workflows/publish-distribution.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -40,4 +40,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -39,7 +39,7 @@ jobs:
             os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [mock-api-test]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
       - name: Install build packages
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-packages-test]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install documentation tools
         run: |
           pip install sphinx sphinx_rtd_theme setuptools-scm


### PR DESCRIPTION
- Last release the build publish failed - https://github.com/smartsheet/smartsheet-python-sdk/actions/runs/10160522219
   -   We're using deprecated actions so have updated them 
- Had a look and there are other actions which have now been deprecated so will fail when we attempt to publish any changes 
  - https://vcc.docs.vrchat.com/guides/upgrading/github-actions-upgrade/
