### PR TITLE
Fallback filename when Content-Disposition header is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] - 2025-04-07
+
+### Changed
+
+- Fallback filename for `DownloadedFile` when `Content-Disposition` header is missing.
+
 ## [3.0.4] - 2024-07-29
 
 ### Changed

--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -520,9 +520,25 @@ class OperationResult:
             if expected != "DownloadedFile":
                 data = self.resp.json()
             else:
-                filename = re.findall(
-                    'filename="(.+)";', self.resp.headers["Content-Disposition"]
-                )
+                # default
+                filename = ["download"]
+
+                if "Content-Disposition" in self.resp.headers:
+                    # use the provided filename
+                    filename = re.findall(
+                        'filename="(.+)";', self.resp.headers["Content-Disposition"]
+                    )
+                else:
+                    content_type = self.resp.headers.get("Content-Type", "")
+                    if content_type in [
+                        "application/vnd.ms-excel",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    ]:
+                        filename[0] += ".xlsx"
+                    elif content_type == "application/pdf":
+                        filename[0] += ".pdf"
+                    elif content_type == "text/csv":
+                        filename[0] += ".csv"
 
                 data = {
                     "resultCode": 0,


### PR DESCRIPTION
# Pull Request

## Description

The `Content-Disposition` header is expected to be present when downloading a sheet as a file. That expectation appears to no longer be always true in practice.

## Related Issue
[issue 67](https://github.com/smartsheet/smartsheet-python-sdk/issues/67)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Environment Information
- Smartsheet API Version: 2.0
- Smartsheet Python SDK Version 3.0.4
- Python Version 3.11.9

## What Changes Were Made
As a fallback, the user will get a default filename of `download`, along with the appropriate suffix when we receive an expected `Content-Type` header.

## Why These Changes Were Made
The file is still being downloaded successfully, so the SDK shouldn't fail. Setting a reasonable fallback so the SDK doesn't raise exceptions on successful download.

## Testing
```python
import os
import smartsheet

def test_download():
    apitoken = os.getenv('SMARTSHEET_ACCESS_TOKEN')
    sheetID = 1434619120772996

    smart = smartsheet.Smartsheet(access_token=apitoken)
    smart.Sheets.get_sheet_as_csv(sheetID, './')
    smart.Sheets.get_sheet_as_excel(sheetID, './')
    smart.Sheets.get_sheet_as_pdf(sheetID, './')

if __name__ == "__main__":
    test_download()
```

## Checklist
- [x] My code follows the [style guidelines](../../../CONTRIBUTING.md#code-style-and-quality) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other context about the PR here -->
