### PR TITLE
Remove build-time dependency on six, add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 42.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import sys
-import six
 
 NAME = 'smartsheet-python-sdk'
 
@@ -28,8 +27,7 @@ class PyTest(TestCommand):
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        if isinstance(self.pytest_args, six.string_types):
-            self.pytest_args = [self.pytest_args]
+        self.pytest_args = [self.pytest_args]
         self.test_args = []
         self.test_suite = True
 


### PR DESCRIPTION
## Type of Change
<!-- Check the relevant option by putting an x in the brackets -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [x] Other (please describe): packaging configuration updates

## What Changes Were Made

Hi, I'm Richard! I'm part of the pip core team.

Starting with pip 25.1, we've deprecated the legacy `setup.py bdist_wheel` based mechanism for building projects. Once the legacy mechanism is removed, pip will exclusively use the modern interface (PEP 517 mode) for installers (e.g., pip) to ask a build backend (e.g., setuptools) to build the project into a wheel (which pip knows how to install).

For more information, please read the deprecation issue: https://github.com/pypa/pip/issues/6334. 

While most projects should NOT be impacted as the modern mechanism is largely backwards compatible, **your project has been identified as one which will fail to install _from source_ when PEP 517 mode is enabled**. Most end-users will NOT be affected as the vast majority of installs are fulfilled using pre-built wheels. _However_, some users (and especially repackagers) prefer to build+install their dependencies from source. 

The failure is caused by **build isolation** which is enabled in PEP 517 mode. Build isolation means that pip will create a temporary Python environment to build the project in, whereas with the legacy behaviour the build occurs within the Python environment where pip is installed.

Your project's `setup.py` file relies on `six` being pre-installed. If six is not installed, pip will not be able to build nor install your project.

<details><summary>Example failure</summary>
<p>

```console
$ pip install . --use-pep517
Processing /home/ichard26/dev/misc/pep518/smartsheet-python-sdk
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      <string>:2: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
      !!
      
              ********************************************************************************
              Please remove any references to `setuptools.command.test` in all supported versions of the affected package.
      
              This deprecation is overdue, please update your project and remove deprecated
              calls to avoid build errors in the future.
              ********************************************************************************
      
      !!
      Traceback (most recent call last):
        File "/home/ichard26/.local/share/vem/envs/pep518-20250511-214044/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/ichard26/.local/share/vem/envs/pep518-20250511-214044/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/ichard26/.local/share/vem/envs/pep518-20250511-214044/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp-ram/pip-build-env-lo5hhtyt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp-ram/pip-build-env-lo5hhtyt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp-ram/pip-build-env-lo5hhtyt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp-ram/pip-build-env-lo5hhtyt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 4, in <module>
      ModuleNotFoundError: No module named 'six'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

</p>
</details> 

I took a look at your `setup.py` and it looks to me that six is in fact not required, thus I've removed it from `setup.py` entirely. I've also added a [`pyproject.toml` file](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/) in which setuptools is declared as your project's build system. This informs installers which packages are needed in order to build the project. Its presence will also cause pip to default to PEP 517 mode for your project, which will help to ensure your project will continue to install correctly with modern pip (and alternative installers like `uv pip`).

If you have any questions, I'd be happy to answer them! It doesn't matter if they're about the pip deprecation specifically or modern Python packaging in general. Thank you!