### PR TITLE
Deprecate and replace workspace and folder endpoints

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -80,7 +80,7 @@ response = client.Passthrough.post('/sheets', payload)
 
 ### Integration Tests
 
-1. Follow the instructions [here](tests/integration/README.md)
+1. Follow the [Integration test instructions](tests/integration/README.md)
 2. Run `pytest tests/integration`
 
 ### Mock API Tests
@@ -134,7 +134,7 @@ using the same `stream_position` value until the next list of events is retrieve
 Many events have additional information available as a part of the event. That information can be accessed using
 the Python dictionary stored in the `additional_details` property (Note that values of the `additional_details`
 dictionary use camelCase/JSON names, e.g. `sheetName` not `sheet_name`). Information about the additional details
-provided can be found [here.](https://smartsheet.redoc.ly/tag/eventsDescription)
+provided can be found on the [Events Description](https://smartsheet.redoc.ly/tag/eventsDescription) page of the API Documentation.
 
 ```python
 # this example is looking specifically for new sheet events

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -157,7 +157,7 @@ last_week = datetime.now() - timedelta(days=7)
 events_list = smartsheet_client.Events.list_events(since=last_week.isoformat(), max_count=1000)
 print_new_sheet_events_in_list(events_list)
 
-# continue listing events in the stream by using the stream_position, if the previous response indicates that more 
+# continue listing events in the stream by using the stream_position, if the previous response indicates that more
 # data is available.
 while events_list.more_available:
     events_list = smartsheet_client.Events.list_events(stream_position=events_list.next_stream_position, max_count=10000,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2025-08-04
+
+### Added
+
+- New `get_workspace_metadata()` method to get workspace metadata without children
+- New `get_workspace_children()` method to get workspace children with filtering and pagination support
+- New `get_folder_metadata()` method to get folder metadata without children
+- New `get_folder_children()` method to get folder children with filtering and pagination support
+- New `TokenPaginatedResult<T>` generic model for type-safe paginated API responses
+- New `PaginatedChildrenResult` model with custom deserialization for mixed children types based on resourceType
+
+### Deprecated
+
+- `get_workspace()` - Use `get_workspace_metadata()` and `get_workspace_children()` instead
+- `list_folders()` in Workspaces - Use `get_workspace_children()` with `children_resource_types=['folders']` instead
+- `get_folder()` - Use `get_folder_metadata()` and `get_folder_children()` instead
+- `list_folders()` in Folders - Use `get_folder_children()` with `children_resource_types=['folders']` instead
+- `create_folder()` in Home
+- `create_sheet()` in Home
+- `create_sheet_from_template()` in Home
+- `list_all_contents()` in Home
+- `list_folders()` in Home
+
 ## [3.0.5] - 2025-04-07
 
 ### Changed
@@ -253,7 +276,7 @@ if sheet.access_level == 'OWNER':
     ...
 ```
 
-[enum34](https://pypi.python.org/pypi/enum34) has been added as a required package for the SDK  
+[enum34](https://pypi.python.org/pypi/enum34) has been added as a required package for the SDK
 
 ## [1.3.0] - 2018-02-21
 

--- a/smartsheet/folders.py
+++ b/smartsheet/folders.py
@@ -286,9 +286,8 @@ class Folders:
 
         Args:
             folder_id (int): Folder ID
-            include (list[str]): A comma-separated list of
-                optional elements to include in the response. Valid list
-                values: source.
+            include (list[str]): A list of optional elements to include
+            in the response. Valid list values: source.
 
         Returns:
             Folder
@@ -312,9 +311,8 @@ class Folders:
             children_resource_types (list[str]): The types of the children resources.
                 If not provided, returns children of all types.
                 Valid list values: sheets, reports, sights, folders.
-            include (list[str]): A comma-separated list of
-                optional elements to include in the response. Valid list
-                values: source, ownerInfo.
+            include (list[str]): A list of optional elements to include in the
+                response. Valid list values: source, ownerInfo.
             last_key (str): The token from a previous request that will allow this one
                 to fetch the next page of results.
             max_items (int): The maximum number of items to return in the response.

--- a/smartsheet/folders.py
+++ b/smartsheet/folders.py
@@ -22,6 +22,7 @@ import os.path
 
 from . import fresh_operation
 from .models.folder import Folder
+from .util import deprecated
 
 
 class Folders:
@@ -173,8 +174,12 @@ class Folders:
 
         return response
 
+    @deprecated
     def get_folder(self, folder_id, include=None):
         """Get the specified Folder (and list its contents).
+
+        Deprecated: 3.1.0
+           Use `get_folder_metadata` and `get_folder_children` instead.
 
         Args:
             folder_id (int): Folder ID
@@ -196,8 +201,12 @@ class Folders:
 
         return response
 
+    @deprecated
     def list_folders(self, folder_id, page_size=None, page=None, include_all=None):
         """Get a list of top-level child Folders within the specified Folder.
+
+        Deprecated: 3.1.0
+           Use `get_folder_children` with children_resource_types=['folders'] instead.
 
         Args:
             folder_id (int): Folder ID
@@ -267,6 +276,61 @@ class Folders:
 
         expected = ["Result", "Folder"]
 
+        prepped_request = self._base.prepare_request(_op)
+        response = self._base.request(prepped_request, expected, _op)
+
+        return response
+
+    def get_folder_metadata(self, folder_id, include=None):
+        """Get the metadata of a folder.
+
+        Args:
+            folder_id (int): Folder ID
+            include (list[str]): A comma-separated list of
+                optional elements to include in the response. Valid list
+                values: source.
+
+        Returns:
+            Folder
+        """
+        _op = fresh_operation("get_folder_metadata")
+        _op["method"] = "GET"
+        _op["path"] = "/folders/" + str(folder_id) + "/metadata"
+        _op["query_params"]["include"] = include
+
+        expected = "Folder"
+        prepped_request = self._base.prepare_request(_op)
+        response = self._base.request(prepped_request, expected, _op)
+
+        return response
+
+    def get_folder_children(self, folder_id, children_resource_types=None, include=None, last_key=None, max_items=None):
+        """Get the children of a folder.
+
+        Args:
+            folder_id (int): Folder ID
+            children_resource_types (list[str]): The types of the children resources.
+                If not provided, returns children of all types.
+                Valid list values: sheets, reports, sights, folders.
+            include (list[str]): A comma-separated list of
+                optional elements to include in the response. Valid list
+                values: source, ownerInfo.
+            last_key (str): The token from a previous request that will allow this one
+                to fetch the next page of results.
+            max_items (int): The maximum number of items to return in the response.
+
+        Returns:
+            PaginatedChildrenResult
+        """
+        _op = fresh_operation("get_folder_children")
+        _op["method"] = "GET"
+        _op["path"] = "/folders/" + str(folder_id) + "/children"
+        _op["query_params"]["childrenResourceTypes"] = children_resource_types
+        _op["query_params"]["include"] = include
+        _op["query_params"]["lastKey"] = last_key
+        _op["query_params"]["maxItems"] = max_items
+
+        expected = "PaginatedChildrenResult"
         prepped_request = self._base.prepare_request(_op)
         response = self._base.request(prepped_request, expected, _op)
 

--- a/smartsheet/home.py
+++ b/smartsheet/home.py
@@ -22,6 +22,7 @@ import logging
 from . import fresh_operation
 from .models.folder import Folder
 from .models.sheet import Sheet
+from .util import deprecated
 
 
 class Home:
@@ -33,6 +34,7 @@ class Home:
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
+    @deprecated
     def create_folder(self, folder_obj):
         """Creates a Folder in the user's Sheets folder (Home).
 
@@ -57,6 +59,7 @@ class Home:
 
         return response
 
+    @deprecated
     def create_sheet(self, sheet_obj):
         """Create a Sheet from scratch in the user's Sheets folder within
         Home.
@@ -82,6 +85,7 @@ class Home:
 
         return response
 
+    @deprecated
     def create_sheet_from_template(self, sheet_obj, include=None):
         """Create a Sheet in the Sheets folder from the specified Template.
 
@@ -118,6 +122,7 @@ class Home:
 
         return response
 
+    @deprecated
     def list_all_contents(self, include=None, exclude=None):
         """Get a nested list of all Home objects, including Sheets,
         Workspaces, Folders, Reports and Templates.
@@ -145,6 +150,7 @@ class Home:
 
         return response
 
+    @deprecated
     def list_folders(self, page_size=None, page=None, include_all=None):
         """Gets a list of top-level child Folders within the user's Sheets
         folder.

--- a/smartsheet/models/__init__.py
+++ b/smartsheet/models/__init__.py
@@ -73,6 +73,8 @@ from .multi_row_email import MultiRowEmail
 from .number_object_value import NumberObjectValue
 from .o_auth_error import OAuthError
 from .object_value import ObjectValue
+from .paginated_children_result import PaginatedChildrenResult
+from .token_paginated_result import TokenPaginatedResult
 from .predecessor import Predecessor
 from .predecessor_list import PredecessorList
 from .project_settings import ProjectSettings

--- a/smartsheet/models/datetime_object_value.py
+++ b/smartsheet/models/datetime_object_value.py
@@ -26,10 +26,10 @@ from .object_value import ObjectValue, six
 
 
 class DatetimeObjectValue(ObjectValue):
-    """Smartsheet DateObjectValue data model."""
+    """Smartsheet DatetimeObjectValue data model."""
 
     def __init__(self, props=None, object_type=None, base_obj=None):
-        """Initialize the DateObjectValue model."""
+        """Initialize the DatetimeObjectValue model."""
         super().__init__(object_type, base_obj)
         self._base = None
         if base_obj is not None:

--- a/smartsheet/models/folder.py
+++ b/smartsheet/models/folder.py
@@ -17,11 +17,12 @@
 
 from __future__ import absolute_import
 
-from ..types import Boolean, Number, String, TypedList, json
+from ..types import Boolean, Number, String, Timestamp, TypedList, TypedObject, json
 from ..util import deserialize, serialize
 from .report import Report
 from .sheet import Sheet
 from .sight import Sight
+from .source import Source
 from .template import Template
 
 
@@ -35,14 +36,17 @@ class Folder:
         if base_obj is not None:
             self._base = base_obj
 
+        self._created_at = Timestamp()
         self._favorite = Boolean()
         self._folders = TypedList(Folder)
         self._id_ = Number()
+        self._modified_at = Timestamp()
         self._name = String()
         self._permalink = String()
         self._reports = TypedList(Report)
         self._sheets = TypedList(Sheet)
         self._sights = TypedList(Sight)
+        self._source = TypedObject(Source)
         self._templates = TypedList(Template)
 
         if props:
@@ -63,6 +67,14 @@ class Folder:
             self.id_ = value
         else:
             super().__setattr__(key, value)
+
+    @property
+    def created_at(self):
+        return self._created_at.value
+
+    @created_at.setter
+    def created_at(self, value):
+        self._created_at.value = value
 
     @property
     def favorite(self):
@@ -87,6 +99,14 @@ class Folder:
     @id_.setter
     def id_(self, value):
         self._id_.value = value
+
+    @property
+    def modified_at(self):
+        return self._modified_at.value
+
+    @modified_at.setter
+    def modified_at(self, value):
+        self._modified_at.value = value
 
     @property
     def name(self):
@@ -127,6 +147,14 @@ class Folder:
     @sights.setter
     def sights(self, value):
         self._sights.load(value)
+
+    @property
+    def source(self):
+        return self._source.value
+
+    @source.setter
+    def source(self, value):
+        self._source.value = value
 
     @property
     def templates(self):

--- a/smartsheet/models/paginated_children_result.py
+++ b/smartsheet/models/paginated_children_result.py
@@ -1,0 +1,80 @@
+# pylint: disable=C0111,R0902,R0904,R0912,R0913,R0915,E1101
+# Smartsheet Python SDK.
+#
+# Copyright 2018 Smartsheet.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"): you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from typing import Union
+from ..util import deserialize
+from .token_paginated_result import TokenPaginatedResult
+from .folder import Folder
+from .sheet import Sheet
+from .sight import Sight
+from .report import Report
+
+# Type alias for children that can be any of these types
+ChildType = Union[Folder, Sheet, Sight, Report]
+
+
+class PaginatedChildrenResult(TokenPaginatedResult[ChildType]):
+    """Smartsheet PaginatedChildrenResult that deserializes mixed children based on resourceType."""
+
+    def __init__(self, props=None, base_obj=None):
+        """Initialize the PaginatedChildrenResult model."""
+        super().__init__(props=None, base_obj=base_obj)
+
+        if props:
+            self._deserialize_data(props)
+            deserialize(self, props)
+
+    def _deserialize_data(self, props):
+        """Custom deserialization for data array based on resourceType."""
+        if 'data' in props:
+            self._data = []
+            for item in props['data']:
+                self.append_data(item)
+
+    def append_data(self, item):
+        """Append data item, converting to appropriate model based on resourceType."""
+        # Get resource type from either dict or object
+        if isinstance(item, dict):
+            resource_type = item.get('resourceType', '').lower()
+        else:
+            resource_type = getattr(item, 'resourceType', '').lower()
+
+        # Convert to appropriate model object based on resource type
+        if resource_type == 'folder':
+            self._data.append(Folder(item, self._base))
+        elif resource_type == 'sheet':
+            self._data.append(Sheet(item, self._base))
+        elif resource_type == 'sight':
+            self._data.append(Sight(item, self._base))
+        elif resource_type == 'report':
+            self._data.append(Report(item, self._base))
+        else:
+            # If no resource type or unknown type, append as-is
+            self._data.append(item)
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        """Custom setter that handles deserialization of mixed resource types."""
+        self._data = []
+        for item in value:
+            self.append_data(item)

--- a/smartsheet/models/token_paginated_result.py
+++ b/smartsheet/models/token_paginated_result.py
@@ -17,61 +17,46 @@
 
 from __future__ import absolute_import
 
-from ..types import Number, String, json
+from typing import TypeVar, Generic, List
+from ..types import String, json
 from ..util import deserialize, serialize
 
+T = TypeVar('T')
 
-class Source:
 
-    """Smartsheet Source data model."""
+class TokenPaginatedResult(Generic[T]):
+    """Smartsheet TokenPaginatedResult data model with generic type support."""
 
     def __init__(self, props=None, base_obj=None):
-        """Initialize the Source model."""
+        """Initialize the TokenPaginatedResult model."""
         self._base = None
         if base_obj is not None:
             self._base = base_obj
 
-        self.allowed_values = {"_type": ["folder", "report", "sheet", "sight", "template", "workspace"]}
-
-        self._id_ = Number()
-        self._type_ = String(accept=self.allowed_values["_type"])
+        self._data = []
+        self._last_key = String()
 
         if props:
             deserialize(self, props)
 
+        self.request_response = None
         self.__initialized = True
 
-    def __getattr__(self, key):
-        if key == "id":
-            return self.id_
-        elif key == "type":
-            return self.type_
-        else:
-            raise AttributeError(key)
+    @property
+    def data(self) -> List[T]:
+        return self._data
 
-    def __setattr__(self, key, value):
-        if key == "id":
-            self.id_ = value
-        elif key == "type":
-            self.type_ = value
-        else:
-            super().__setattr__(key, value)
+    @data.setter
+    def data(self, value):
+        self._data = value
 
     @property
-    def id_(self):
-        return self._id_.value
+    def last_key(self):
+        return self._last_key.value
 
-    @id_.setter
-    def id_(self, value):
-        self._id_.value = value
-
-    @property
-    def type_(self):
-        return self._type_.value
-
-    @type_.setter
-    def type_(self, value):
-        self._type_.value = value
+    @last_key.setter
+    def last_key(self, value):
+        self._last_key.value = value
 
     def to_dict(self):
         return serialize(self)

--- a/smartsheet/models/workspace.py
+++ b/smartsheet/models/workspace.py
@@ -17,13 +17,14 @@
 
 from __future__ import absolute_import
 
-from ..types import Boolean, EnumeratedValue, Number, String, TypedList, json
+from ..types import Boolean, EnumeratedValue, Number, String, Timestamp, TypedList, TypedObject, json
 from ..util import deserialize, serialize
 from .enums import AccessLevel
 from .folder import Folder
 from .report import Report
 from .sheet import Sheet
 from .sight import Sight
+from .source import Source
 from .template import Template
 
 
@@ -38,14 +39,17 @@ class Workspace:
             self._base = base_obj
 
         self._access_level = EnumeratedValue(AccessLevel)
+        self._created_at = Timestamp()
         self._favorite = Boolean()
         self._folders = TypedList(Folder)
         self._id_ = Number()
+        self._modified_at = Timestamp()
         self._name = String()
         self._permalink = String()
         self._reports = TypedList(Report)
         self._sheets = TypedList(Sheet)
         self._sights = TypedList(Sight)
+        self._source = TypedObject(Source)
         self._templates = TypedList(Template)
 
         if props:
@@ -76,6 +80,14 @@ class Workspace:
         self._access_level.set(value)
 
     @property
+    def created_at(self):
+        return self._created_at.value
+
+    @created_at.setter
+    def created_at(self, value):
+        self._created_at.value = value
+
+    @property
     def favorite(self):
         return self._favorite.value
 
@@ -98,6 +110,14 @@ class Workspace:
     @id_.setter
     def id_(self, value):
         self._id_.value = value
+
+    @property
+    def modified_at(self):
+        return self._modified_at.value
+
+    @modified_at.setter
+    def modified_at(self, value):
+        self._modified_at.value = value
 
     @property
     def name(self):
@@ -138,6 +158,14 @@ class Workspace:
     @sights.setter
     def sights(self, value):
         self._sights.load(value)
+
+    @property
+    def source(self):
+        return self._source.value
+
+    @source.setter
+    def source(self, value):
+        self._source.value = value
 
     @property
     def templates(self):

--- a/smartsheet/workspaces.py
+++ b/smartsheet/workspaces.py
@@ -443,9 +443,8 @@ class Workspaces:
 
         Args:
             workspace_id (int): Workspace ID
-            include (list[str]): A comma-separated list of
-                optional elements to include in the response. Valid list
-                values: source
+            include (list[str]): A list of optional elements to include
+                in the response. Valid list values: source
 
         Returns:
             Workspace
@@ -469,9 +468,8 @@ class Workspaces:
             children_resource_types (list[str]): The types of the children resources.
                 If not provided, returns children of all types.
                 Valid list values: sheets, reports, sights, folders.
-            include (list[str]): A comma-separated list of
-                optional elements to include in the response. Valid list
-                values: source, ownerInfo.
+            include (list[str]): A list of optional elements to include in the response.
+                Valid list values: source, ownerInfo.
             last_key (str): The token from a previous request that will allow this one
                 to fetch the next page of results.
             max_items (int): The maximum number of items to return in the response.

--- a/smartsheet/workspaces.py
+++ b/smartsheet/workspaces.py
@@ -22,6 +22,7 @@ import os.path
 
 from . import fresh_operation
 from .models.folder import Folder
+from .util import deprecated
 
 
 class Workspaces:
@@ -235,8 +236,12 @@ class Workspaces:
 
         return response
 
+    @deprecated
     def get_workspace(self, workspace_id, load_all=False, include=None):
         """Get the specified Workspace and list its contents.
+
+        Deprecated: 3.1.0
+           Use `get_workspace_metadata` and `get_workspace_children` instead.
 
         Get the specified Workspace and list its contents. By
         default, this operation only returns top-level items in the
@@ -266,9 +271,13 @@ class Workspaces:
 
         return response
 
+    @deprecated
     def list_folders(self, workspace_id, page_size=None, page=None, include_all=None):
         """Get a list of top-level child Folders within the specified
         Workspace.
+
+        Deprecated: 3.1.0
+           Use `get_workspace_children` with children_resource_types=['folders'] instead.
 
         Args:
             workspace_id (int): Workspace ID
@@ -424,6 +433,61 @@ class Workspaces:
 
         expected = ["Result", "Workspace"]
 
+        prepped_request = self._base.prepare_request(_op)
+        response = self._base.request(prepped_request, expected, _op)
+
+        return response
+
+    def get_workspace_metadata(self, workspace_id, include=None):
+        """Get metadata of a workspace.
+
+        Args:
+            workspace_id (int): Workspace ID
+            include (list[str]): A comma-separated list of
+                optional elements to include in the response. Valid list
+                values: source
+
+        Returns:
+            Workspace
+        """
+        _op = fresh_operation("get_workspace_metadata")
+        _op["method"] = "GET"
+        _op["path"] = "/workspaces/" + str(workspace_id) + "/metadata"
+        _op["query_params"]["include"] = include
+
+        expected = "Workspace"
+        prepped_request = self._base.prepare_request(_op)
+        response = self._base.request(prepped_request, expected, _op)
+
+        return response
+
+    def get_workspace_children(self, workspace_id, children_resource_types=None, include=None, last_key=None, max_items=None):
+        """Get children of a workspace.
+
+        Args:
+            workspace_id (int): Workspace ID
+            children_resource_types (list[str]): The types of the children resources.
+                If not provided, returns children of all types.
+                Valid list values: sheets, reports, sights, folders.
+            include (list[str]): A comma-separated list of
+                optional elements to include in the response. Valid list
+                values: source, ownerInfo.
+            last_key (str): The token from a previous request that will allow this one
+                to fetch the next page of results.
+            max_items (int): The maximum number of items to return in the response.
+
+        Returns:
+            PaginatedChildrenResult
+        """
+        _op = fresh_operation("get_workspace_children")
+        _op["method"] = "GET"
+        _op["path"] = "/workspaces/" + str(workspace_id) + "/children"
+        _op["query_params"]["childrenResourceTypes"] = children_resource_types
+        _op["query_params"]["include"] = include
+        _op["query_params"]["lastKey"] = last_key
+        _op["query_params"]["maxItems"] = max_items
+
+        expected = "PaginatedChildrenResult"
         prepped_request = self._base.prepare_request(_op)
         response = self._base.request(prepped_request, expected, _op)
 

--- a/tests/integration/test_folders.py
+++ b/tests/integration/test_folders.py
@@ -64,6 +64,55 @@ class TestFolders:
         action = smart.Folders.get_folder(smart_setup['folder'].id)
         assert 'app.smartsheet.com' in action.permalink
 
+    def test_get_folder_metadata(self, smart_setup):
+        smart = smart_setup['smart']
+        folder = smart.Folders.get_folder_metadata(smart_setup['folder'].id)
+        assert isinstance(folder, smart.models.folder.Folder)
+        assert folder.id == smart_setup['folder'].id
+        assert folder.name is not None
+
+    def test_get_folder_metadata_with_include(self, smart_setup):
+        smart = smart_setup['smart']
+        folder = smart.Folders.get_folder_metadata(
+            smart_setup['folder'].id,
+            include=['source']
+        )
+        assert isinstance(folder, smart.models.folder.Folder)
+        assert folder.id == smart_setup['folder'].id
+
+    def test_get_folder_children(self, smart_setup):
+        smart = smart_setup['smart']
+        children = smart.Folders.get_folder_children(smart_setup['folder'].id)
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
+    def test_get_folder_children_with_filters(self, smart_setup):
+        smart = smart_setup['smart']
+        # Test with resource type filter
+        children = smart.Folders.get_folder_children(
+            smart_setup['folder'].id,
+            children_resource_types=['folders']
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+        # Verify all children are of the filtered type
+        for child in children.data:
+            assert isinstance(child, smart.models.folder.Folder)
+
+        # Test with include parameter
+        children = smart.Folders.get_folder_children(
+            smart_setup['folder'].id,
+            include=['source', 'ownerInfo']
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
+    def test_get_folder_children_with_pagination(self, smart_setup):
+        smart = smart_setup['smart']
+        # Test with pagination parameters
+        children = smart.Folders.get_folder_children(
+            smart_setup['folder'].id,
+            max_items=100
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
     def test_delete_folder(self, smart_setup):
         smart = smart_setup['smart']
         action = smart.Folders.delete_folder(TestFolders.copied_folder.id)

--- a/tests/integration/test_workspaces.py
+++ b/tests/integration/test_workspaces.py
@@ -134,6 +134,55 @@ class TestWorkspaces:
         )
         assert action.message == 'SUCCESS'
 
+    def test_get_workspace_metadata(self, smart_setup):
+        smart = smart_setup['smart']
+        workspace = smart.Workspaces.get_workspace_metadata(TestWorkspaces.a.id)
+        assert isinstance(workspace, smart.models.workspace.Workspace)
+        assert workspace.id == TestWorkspaces.a.id
+        assert workspace.name is not None
+
+    def test_get_workspace_metadata_with_include(self, smart_setup):
+        smart = smart_setup['smart']
+        workspace = smart.Workspaces.get_workspace_metadata(
+            TestWorkspaces.a.id,
+            include=['source']
+        )
+        assert isinstance(workspace, smart.models.workspace.Workspace)
+        assert workspace.id == TestWorkspaces.a.id
+
+    def test_get_workspace_children(self, smart_setup):
+        smart = smart_setup['smart']
+        children = smart.Workspaces.get_workspace_children(TestWorkspaces.a.id)
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
+    def test_get_workspace_children_with_filters(self, smart_setup):
+        smart = smart_setup['smart']
+        # Test with resource type filter
+        children = smart.Workspaces.get_workspace_children(
+            TestWorkspaces.a.id,
+            children_resource_types=['folders']
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+        # Verify all children are of the filtered type
+        for child in children.data:
+            assert isinstance(child, smart.models.folder.Folder)
+
+        # Test with include parameter
+        children = smart.Workspaces.get_workspace_children(
+            TestWorkspaces.a.id,
+            include=['source', 'ownerInfo']
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
+    def test_get_workspace_children_with_pagination(self, smart_setup):
+        smart = smart_setup['smart']
+        # Test with pagination parameters
+        children = smart.Workspaces.get_workspace_children(
+            TestWorkspaces.a.id,
+            max_items=100
+        )
+        assert isinstance(children, smart.models.paginated_children_result.PaginatedChildrenResult)
+
     def test_update_workspace(self, smart_setup):
         smart = smart_setup['smart']
         new_workspace = smart.models.Workspace()

--- a/tests/mock_api/test_mock_api_folders.py
+++ b/tests/mock_api/test_mock_api_folders.py
@@ -1,0 +1,160 @@
+# pylint: disable=C0103,W0232
+
+import pytest
+from smartsheet.models import Folder, PaginatedChildrenResult, Sheet, Sight, Report
+from smartsheet.exceptions import ApiError
+from mock_api_test_helper import MockApiTestHelper, clean_api_error
+
+
+class TestMockApiFolders(MockApiTestHelper):
+    @clean_api_error
+    def test_get_folder_metadata_no_params(self):
+        self.client.as_test_scenario('Get Folder Metadata - No Params')
+
+        response = self.client.Folders.get_folder_metadata(456)
+
+        assert isinstance(response, Folder)
+        assert response.id == 456
+        assert response.name == "Project Folder"
+        assert response.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        # Verify source is not included when not requested
+        assert not hasattr(response, 'source') or response.source is None
+
+    @clean_api_error
+    def test_get_folder_metadata_include_source(self):
+        self.client.as_test_scenario('Get Folder Metadata - Include Source')
+
+        response = self.client.Folders.get_folder_metadata(
+            456,
+            include=['source']
+        )
+
+        assert isinstance(response, Folder)
+        assert response.id == 456
+        assert response.name == "Project Folder"
+        # Verify source is included
+        assert response.source is not None
+        assert response.source.id == 888
+        assert response.source.type == "folder"
+
+    @clean_api_error
+    def test_get_folder_children_no_params(self):
+        self.client.as_test_scenario('Get Folder Children - No Params')
+
+        response = self.client.Folders.get_folder_children(456)
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 4
+
+        # Verify first child (subfolder)
+        subfolder = response.data[0]
+        assert isinstance(subfolder, Folder)
+        assert subfolder.id == 987
+        assert subfolder.name == "Subfolder"
+
+        # Verify second child (sheet)
+        sheet = response.data[1]
+        assert isinstance(sheet, Sheet)
+        assert sheet.id == 234
+        assert sheet.name == "Task List"
+        assert sheet.access_level == "EDITOR"
+
+        # Verify third child (sight)
+        sight = response.data[2]
+        assert isinstance(sight, Sight)
+        assert sight.id == 567
+        assert sight.name == "Project Dashboard"
+        assert sight.access_level == "EDITOR"
+
+        # Verify fourth child (report)
+        report = response.data[3]
+        assert isinstance(report, Report)
+        assert report.id == 890
+        assert report.name == "Status Report"
+        assert report.access_level == "VIEWER"
+
+    @clean_api_error
+    def test_get_folder_children_filter_sights_and_reports(self):
+        self.client.as_test_scenario('Get Folder Children - Filter Sights and Reports')
+
+        response = self.client.Folders.get_folder_children(
+            456,
+            children_resource_types=['reports', 'sights']
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 3
+
+        # Verify first child (sight)
+        sight1 = response.data[0]
+        assert isinstance(sight1, Sight)
+        assert sight1.id == 567
+        assert sight1.name == "Project Dashboard"
+        assert sight1.access_level == "EDITOR"
+
+        # Verify second child (sight)
+        sight2 = response.data[1]
+        assert isinstance(sight2, Sight)
+        assert sight2.id == 1567
+        assert sight2.name == "Executive Summary"
+        assert sight2.access_level == "VIEWER"
+
+        # Verify third child (report)
+        report = response.data[2]
+        assert isinstance(report, Report)
+        assert report.id == 890
+        assert report.name == "Status Report"
+        assert report.access_level == "VIEWER"
+
+    @clean_api_error
+    def test_get_folder_children_include_source_and_owner_info(self):
+        self.client.as_test_scenario('Get Folder Children - Include Source and OwnerInfo')
+
+        response = self.client.Folders.get_folder_children(
+            456,
+            include=['source', 'ownerInfo']
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 4
+
+        # Verify first child (subfolder) has source but no ownerInfo
+        subfolder = response.data[0]
+        assert isinstance(subfolder, Folder)
+        assert subfolder.id == 987
+        assert subfolder.name == "Subfolder"
+        assert subfolder.source is not None
+        assert subfolder.source.id == 444
+        assert subfolder.source.type == "folder"
+
+        # Verify second child (sheet) has both source and ownerInfo
+        sheet = response.data[1]
+        assert isinstance(sheet, Sheet)
+        assert sheet.id == 234
+        assert sheet.name == "Task List"
+        assert sheet.access_level == "EDITOR"
+        assert sheet.source is not None
+        assert sheet.source.id == 333
+        assert sheet.source.type == "sheet"
+        assert sheet.owner_id == 2002
+        assert sheet.owner == "jane.smith@example.com"
+
+        # Verify third child (sight) has source
+        sight = response.data[2]
+        assert isinstance(sight, Sight)
+        assert sight.id == 567
+        assert sight.name == "Project Dashboard"
+        assert sight.access_level == "EDITOR"
+        assert sight.source is not None
+        assert sight.source.id == 222
+        assert sight.source.type == "sight"
+
+        # Verify fourth child (report) has source
+        report = response.data[3]
+        assert isinstance(report, Report)
+        assert report.id == 890
+        assert report.name == "Status Report"
+        assert report.access_level == "VIEWER"
+        assert report.source is not None
+        assert report.source.id == 111
+        assert report.source.type == "report"

--- a/tests/mock_api/test_mock_api_folders.py
+++ b/tests/mock_api/test_mock_api_folders.py
@@ -158,3 +158,27 @@ class TestMockApiFolders(MockApiTestHelper):
         assert report.source is not None
         assert report.source.id == 111
         assert report.source.type == "report"
+
+    @clean_api_error
+    def test_get_folder_children_max_items_and_last_key(self):
+        self.client.as_test_scenario('Get Folder Children - MaxItems and LastKey')
+
+        response = self.client.Folders.get_folder_children(
+            456,
+            max_items=100,
+            last_key="aslkjf4wlkta4n4900sjfklf499sjwlk4356lkj"
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 1
+
+        # Verify the single child (sight) matches the expected values
+        sight = response.data[0]
+        assert isinstance(sight, Sight)
+        assert sight.id == 567
+        assert sight.name == "Project Dashboard"
+        assert sight.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert sight.access_level == "EDITOR"
+
+        # Verify the lastKey is returned in the response
+        assert response.last_key == "xvmnw4mnx8v9wriot20574xvnjoqt4iuhnow490"

--- a/tests/mock_api/test_mock_api_workspaces.py
+++ b/tests/mock_api/test_mock_api_workspaces.py
@@ -167,3 +167,27 @@ class TestMockApiWorkspaces(MockApiTestHelper):
         assert report.source is not None
         assert report.source.id == 555
         assert report.source.type == "report"
+
+    @clean_api_error
+    def test_get_workspace_children_max_items_and_last_key(self):
+        self.client.as_test_scenario('Get Workspace Children - MaxItems and LastKey')
+
+        response = self.client.Workspaces.get_workspace_children(
+            123,
+            max_items=1000,
+            last_key="aslkjf4wlkta4n4900sjfklf499sjwlk4356lkj"
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 1
+
+        # Verify the single child (sheet) matches the expected values
+        sheet = response.data[0]
+        assert isinstance(sheet, Sheet)
+        assert sheet.id == 789
+        assert sheet.name == "Budget Sheet"
+        assert sheet.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert sheet.access_level == "EDITOR"
+
+        # Verify the lastKey is returned in the response
+        assert response.last_key == "xvmnw4mnx8v9wriot20574xvnjoqt4iuhnow490"

--- a/tests/mock_api/test_mock_api_workspaces.py
+++ b/tests/mock_api/test_mock_api_workspaces.py
@@ -1,0 +1,169 @@
+# pylint: disable=C0103,W0232
+
+import pytest
+from smartsheet.models import Workspace, PaginatedChildrenResult, Folder, Sheet, Sight, Report
+from smartsheet.exceptions import ApiError
+from mock_api_test_helper import MockApiTestHelper, clean_api_error
+
+
+class TestMockApiWorkspaces(MockApiTestHelper):
+    @clean_api_error
+    def test_get_workspace_metadata_no_params(self):
+        self.client.as_test_scenario('Get Workspace Metadata - No Params')
+
+        response = self.client.Workspaces.get_workspace_metadata(123)
+
+        assert isinstance(response, Workspace)
+        assert response.id == 123
+        assert response.name == "Sample Workspace"
+        assert response.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert response.access_level == "VIEWER"
+        assert response.created_at is not None
+        assert response.modified_at is not None
+        # Verify source is not included when not requested
+        assert not hasattr(response, 'source') or response.source is None
+
+    @clean_api_error
+    def test_get_workspace_metadata_include_source(self):
+        self.client.as_test_scenario('Get Workspace Metadata - Include Source')
+
+        response = self.client.Workspaces.get_workspace_metadata(
+            123,
+            include=['source']
+        )
+
+        assert isinstance(response, Workspace)
+        assert response.id == 123
+        assert response.name == "Sample Workspace"
+        assert response.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert response.access_level == "ADMIN"
+        # Verify source is included with exact values
+        assert response.source is not None
+        assert response.source.id == 999
+        assert response.source.type == "workspace"
+
+    @clean_api_error
+    def test_get_workspace_children_no_params(self):
+        self.client.as_test_scenario('Get Workspace Children - No Params')
+
+        response = self.client.Workspaces.get_workspace_children(123)
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 4
+
+        # Verify first child (folder) - exact values from scenario
+        folder = response.data[0]
+        assert isinstance(folder, Folder)
+        assert folder.id == 456
+        assert folder.name == "Project Folder"
+        assert folder.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+
+        # Verify second child (sheet) - exact values from scenario
+        sheet = response.data[1]
+        assert isinstance(sheet, Sheet)
+        assert sheet.id == 789
+        assert sheet.name == "Budget Sheet"
+        assert sheet.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert sheet.access_level == "EDITOR"
+
+        # Verify third child (sight) - exact values from scenario
+        sight = response.data[2]
+        assert isinstance(sight, Sight)
+        assert sight.id == 321
+        assert sight.name == "Dashboard Overview"
+        assert sight.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert sight.access_level == "VIEWER"
+
+        # Verify fourth child (report) - exact values from scenario
+        report = response.data[3]
+        assert isinstance(report, Report)
+        assert report.id == 654
+        assert report.name == "Monthly Report"
+        assert report.permalink == "https://app.smartsheet.com/b/home?lx=*****************"
+        assert report.access_level == "ADMIN"
+
+
+    @clean_api_error
+    def test_get_workspace_children_filter_sheets_and_folders(self):
+        self.client.as_test_scenario('Get Workspace Children - Filter Sheets and Folders')
+
+        response = self.client.Workspaces.get_workspace_children(
+            123,
+            children_resource_types=['folders', 'sheets']
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 3
+
+        # Verify first child (folder)
+        folder = response.data[0]
+        assert isinstance(folder, Folder)
+        assert folder.id == 456
+        assert folder.name == "Project Folder"
+
+        # Verify second child (sheet)
+        sheet1 = response.data[1]
+        assert isinstance(sheet1, Sheet)
+        assert sheet1.id == 789
+        assert sheet1.name == "Budget Sheet"
+        assert sheet1.access_level == "EDITOR"
+
+        # Verify third child (sheet)
+        sheet2 = response.data[2]
+        assert isinstance(sheet2, Sheet)
+        assert sheet2.id == 1234
+        assert sheet2.name == "Project Timeline"
+        assert sheet2.access_level == "EDITOR"
+
+    @clean_api_error
+    def test_get_workspace_children_include_source_and_owner_info(self):
+        self.client.as_test_scenario('Get Workspace Children - Include Source and OwnerInfo')
+
+        response = self.client.Workspaces.get_workspace_children(
+            123,
+            include=['source', 'ownerInfo']
+        )
+
+        assert isinstance(response, PaginatedChildrenResult)
+        assert len(response.data) == 4
+
+        # Verify first child (folder) has source but no ownerInfo - real values
+        folder = response.data[0]
+        assert isinstance(folder, Folder)
+        assert folder.id == 456
+        assert folder.name == "Project Folder"
+        assert folder.source is not None
+        assert folder.source.id == 888
+        assert folder.source.type == "folder"
+
+        # Verify second child (sheet) has both source and ownerInfo - real values
+        sheet = response.data[1]
+        assert isinstance(sheet, Sheet)
+        assert sheet.id == 789
+        assert sheet.name == "Budget Sheet"
+        assert sheet.access_level == "EDITOR"
+        assert sheet.source is not None
+        assert sheet.source.id == 777
+        assert sheet.source.type == "sheet"
+        assert sheet.owner_id == 1001
+        assert sheet.owner == "john.doe@example.com"
+
+        # Verify third child (sight) has source - real values
+        sight = response.data[2]
+        assert isinstance(sight, Sight)
+        assert sight.id == 321
+        assert sight.name == "Dashboard Overview"
+        assert sight.access_level == "VIEWER"
+        assert sight.source is not None
+        assert sight.source.id == 666
+        assert sight.source.type == "sight"
+
+        # Verify fourth child (report) has source - real values
+        report = response.data[3]
+        assert isinstance(report, Report)
+        assert report.id == 654
+        assert report.name == "Monthly Report"
+        assert report.access_level == "ADMIN"
+        assert report.source is not None
+        assert report.source.id == 555
+        assert report.source.type == "report"


### PR DESCRIPTION
# Pull Request

## Description
This update marks as deprecated several endpoints relating to Workspaces, Folders, and Home. New endpoints are added to replace deprecated Workspaces and Folders endpoints. 


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [x] Other (please describe): Deprecations

## Environment Information
<!-- Please complete the following information -->
- Smartsheet API Version: [e.g. 2.0]
- Smartsheet Python SDK Version: 3.1.0

## What Changes Were Made


### Added

- New `get_workspace_metadata()` method to get workspace metadata without children
- New `get_workspace_children()` method to get workspace children with filtering and pagination support
- New `get_folder_metadata()` method to get folder metadata without children
- New `get_folder_children()` method to get folder children with filtering and pagination support
- New `TokenPaginatedResult<T>` generic model for type-safe paginated API responses
- New `PaginatedChildrenResult` model with custom deserialization for mixed children types based on resourceType

### Deprecated

- `get_workspace()` - Use `get_workspace_metadata()` and `get_workspace_children()` instead
- `list_folders()` in Workspaces - Use `get_workspace_children()` with `children_resource_types=['folders']` instead
- `get_folder()` - Use `get_folder_metadata()` and `get_folder_children()` instead
- `list_folders()` in Folders - Use `get_folder_children()` with `children_resource_types=['folders']` instead
- `create_folder()` in Home
- `create_sheet()` in Home
- `create_sheet_from_template()` in Home
- `list_all_contents()` in Home
- `list_folders()` in Home


## Why These Changes Were Made
Corresponding changes have been made in the Smartsheet Public API to deprecate and provide the endpoints described above. This change signals to users the endpoints that are now deprecated, and provides functions for calling new endpoints.

## Testing
* Added and tested mock-api tests. 
* Added and tested integration tests. 
* Performed basic testing of new functions. 

## Checklist
<!-- Check all that apply -->
- [x] My code follows the [style guidelines](../../../CONTRIBUTING.md#code-style-and-quality) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
See the API Documentation Changelog entry: https://developers.smartsheet.com/api/smartsheet/changelog#folder-and-workspace-pagination-and-fetching