### PR TITLE
Add provisionalExpirationDate field to the user_model and user_plan models 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.3.0] - 2025-09-25
+## [3.3.0] - 2025-10-07
 
 ### Added
 - Add provisionalExpirationDate field to the user_model and user_plan models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2025-09-25
+
+### Added
+- Add provisionalExpirationDate field to the user_model and user_plan models
+
 ## [3.2.0] - 2025-09-25
 
 ### Added

--- a/smartsheet/models/user_model.py
+++ b/smartsheet/models/user_model.py
@@ -51,6 +51,7 @@ class UserModel:
         self._licensed_sheet_creator = Boolean()
         self._mobile_phone = String()
         self._profile_image = TypedObject(ProfileImage)
+        self._provisional_expiration_date = Timestamp()
         self._resource_viewer = Boolean()
         self._role = String()
         self._seat_type = EnumeratedValue(SeatType)
@@ -196,6 +197,14 @@ class UserModel:
     @profile_image.setter
     def profile_image(self, value):
         self._profile_image.value = value
+
+    @property
+    def provisional_expiration_date(self):
+        return self._provisional_expiration_date.value
+
+    @provisional_expiration_date.setter
+    def provisional_expiration_date(self, value):
+        self._provisional_expiration_date.value = value
 
     @property
     def resource_viewer(self):

--- a/smartsheet/models/user_plan.py
+++ b/smartsheet/models/user_plan.py
@@ -20,6 +20,7 @@ class UserPlan:
         self._seat_type = EnumeratedValue(SeatType)
         self._seat_type_last_changed_at = Timestamp()
         self._is_internal = Boolean()
+        self._provisional_expiration_date = Timestamp()
 
         if props:
             deserialize(self, props)
@@ -57,6 +58,14 @@ class UserPlan:
     @is_internal.setter
     def is_internal(self, value):
         self._is_internal.value = value
+
+    @property
+    def provisional_expiration_date(self):
+        return self._provisional_expiration_date.value
+
+    @provisional_expiration_date.setter
+    def provisional_expiration_date(self, value):
+        self._provisional_expiration_date.value = value
 
     def to_dict(self):
         return serialize(self)


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->
Add provisionalExpirationDate field to the user_model and user_plan models 

## Related Issue
<!-- Link to the related issue (if applicable) -->

## Type of Change
<!-- Check the relevant option by putting an x in the brackets -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Environment Information
<!-- Please complete the following information -->
- Smartsheet API Version: [e.g. 2.0]
- Smartsheet Python SDK Version: [e.g. 3.0.0]
- Python Version: [e.g. 3.10]

## What Changes Were Made
<!-- Describe the changes you've made in detail -->
In user_model and user_plan models add provisionalExpirationDate

## Why These Changes Were Made
<!-- Explain the reasoning behind these changes -->

## Testing
<!-- Describe the testing you've done to validate your changes -->
The purpose of the field is to see the expiration time of members, which have the provisional seat types. 

## Checklist
<!-- Check all that apply -->
- [ ] My code follows the [style guidelines](../../../CONTRIBUTING.md#code-style-and-quality) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other context about the PR here -->
