### PR TITLE
Specify list results in SDK methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+### Fixed
+
+- Update correct method types, which may return either list or a singleton object
+
 ## [3.7.0] - 2025-12-11
 
 ### Added

--- a/smartsheet/favorites.py
+++ b/smartsheet/favorites.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import
 
-from typing import Union
+from typing import Union, List
 
 import logging
 
@@ -34,7 +34,7 @@ class Favorites:
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
-    def add_favorites(self, favorite_obj) -> Union[Result[Favorite], Error]:
+    def add_favorites(self, favorite_obj) -> Union[Result[Union[Favorite, List[Favorite]]], Error]:
         """Add one or more items to the user's list of Favorite items.
 
         Adds one or more items to the user's list of Favorite
@@ -50,7 +50,7 @@ class Favorites:
                 more Favorite objects
 
         Returns:
-            Union[Result[Favorite], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[Union[Favorite, List[Favorite]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
         """
         _op = fresh_operation("add_favorites")
         _op["method"] = "POST"

--- a/smartsheet/favorites.py
+++ b/smartsheet/favorites.py
@@ -50,7 +50,8 @@ class Favorites:
                 more Favorite objects
 
         Returns:
-            Union[Result[Union[Favorite, List[Favorite]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
+            Union[Result[Union[Favorite, List[Favorite]]], Error]: The result of the operation - either a list or a
+            single object, or an Error object if the request fails.
         """
         _op = fresh_operation("add_favorites")
         _op["method"] = "POST"

--- a/smartsheet/groups.py
+++ b/smartsheet/groups.py
@@ -43,7 +43,8 @@ class Groups:
                 object(s).
 
         Returns:
-            Union[Result[Union[GroupMember, List[GroupMember]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
+            Union[Result[Union[GroupMember, List[GroupMember]]], Error]: The result of the operation - either a list or
+            a single object, or an Error object if the request fails.
         """
         _op = fresh_operation("add_members")
         _op["method"] = "POST"

--- a/smartsheet/groups.py
+++ b/smartsheet/groups.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import
 
-from typing import Union
+from typing import Union, List
 
 import logging
 
@@ -34,7 +34,7 @@ class Groups:
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
-    def add_members(self, group_id, group_member_obj) -> Union[Result[GroupMember], Error]:
+    def add_members(self, group_id, group_member_obj) -> Union[Result[Union[GroupMember, List[GroupMember]]], Error]:
         """Add one or more members to a Group.
 
         Args:
@@ -43,7 +43,7 @@ class Groups:
                 object(s).
 
         Returns:
-            Union[Result[GroupMember], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[Union[GroupMember, List[GroupMember]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
         """
         _op = fresh_operation("add_members")
         _op["method"] = "POST"

--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 import logging
 import os.path
 from datetime import datetime
-from typing import Union
+from typing import Union, List
 
 import six
 
@@ -40,7 +40,7 @@ class Sheets:
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
-    def add_columns(self, sheet_id, list_of_columns) -> Union[Result[Column], Error]:
+    def add_columns(self, sheet_id, list_of_columns) -> Union[Result[Union[Column, List[Column]]], Error]:
         """Insert one or more Columns into the specified Sheet
 
         Args:
@@ -49,7 +49,7 @@ class Sheets:
                 Column objects
 
         Returns:
-            Union[Result[Column], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[Union[Column, List[Column]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
         """
 
         if isinstance(list_of_columns, (dict, Column)):
@@ -69,7 +69,7 @@ class Sheets:
 
         return response
 
-    def add_rows(self, sheet_id, list_of_rows) -> Union[Result[Row], Error]:
+    def add_rows(self, sheet_id, list_of_rows) -> Union[Result[Union[Row, List[Row]]], Error]:
         """Insert one or more Rows into the specified Sheet.
 
         If multiple rows are specified in the request, all rows
@@ -109,7 +109,7 @@ class Sheets:
                    hyperlink (optional)
 
         Returns:
-            Union[Result[Row], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[Union[Row, List[Row]]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
         """
         if isinstance(list_of_rows, (dict, Row)):
             arg_value = list_of_rows
@@ -281,7 +281,7 @@ class Sheets:
 
         return response
 
-    def delete_rows(self, sheet_id, ids, ignore_rows_not_found=False) -> Union[Result[NumberObjectValue], Error]:
+    def delete_rows(self, sheet_id, ids, ignore_rows_not_found=False) -> Union[Result[List[NumberObjectValue]], Error]:
         """Deletes one or more Row(s) from the specified Sheeet.
 
         Args:
@@ -296,7 +296,7 @@ class Sheets:
                 will be altered).
 
         Returns:
-            Union[Result[NumberObjectValue], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[List[NumberObjectValue]], Error]: The result of the operation - a list of deleted object IDs, or an Error object if the request fails.
         """
         _op = fresh_operation("delete_rows")
         _op["method"] = "DELETE"

--- a/smartsheet/users.py
+++ b/smartsheet/users.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import
 
-from typing import Union
+from typing import Union, List
 
 import logging
 from datetime import datetime
@@ -36,7 +36,7 @@ class Users:
         self._base = smartsheet_obj
         self._log = logging.getLogger(__name__)
 
-    def add_alternate_email(self, user_id, list_of_alternate_emails) -> Union[Result[AlternateEmail], Error]:
+    def add_alternate_email(self, user_id, list_of_alternate_emails) -> Union[Result[Union[AlternateEmail, List[AlternateEmail]]], Error]:
         """Add one or more alternate email addresses for the specified User
 
         Args:
@@ -45,7 +45,7 @@ class Users:
                 An array of one or more AlternateEmail objects.
 
         Returns:
-            Union[Result[AlternateEmail], Error]: The result of the operation, or an Error object if the request fails.
+            Union[Result[List[AlternateEmail]], Error]: The result of the operation - either a list or a single object, or an Error object if the request fails.
         """
         _op = fresh_operation("add_alternate_email")
         _op["method"] = "POST"


### PR DESCRIPTION
# Pull Request

## Description
Some return types of the SDK methods and subsequently the public API support both a singleton item result and a list of them. This MR adds the proper notation for those methods using Union types.

## Type of Change
<!-- Check the relevant option by putting an x in the brackets -->
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Environment Information
<!-- Please complete the following information -->
- Smartsheet API Version: 2.0
- Smartsheet Python SDK Version: 3.7.1
- Python Version: 3.7

## What Changes Were Made
Update the return types of the affected methods.

## Checklist
<!-- Check all that apply -->
- [ ] My code follows the [style guidelines](../../../CONTRIBUTING.md#code-style-and-quality) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated the relevant files in `docs-source/` (see [Documentation guidelines](../../../CONTRIBUTING.md#documentation))
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
