### PR TITLE
adds Cells to Smartsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+### Added
+
+- Add `Cells` class to `Smartsheet` class for IDE autocomplete support. Now auto-complete like `smart.Cells.get_cell_history()` and `smart.Cells.add_image_to_cell()` will work.
+
 ## [3.7.1] - 2025-12-12
 
 ### Fixed

--- a/smartsheet/smartsheet.py
+++ b/smartsheet/smartsheet.py
@@ -38,6 +38,7 @@ from .session import pinned_session
 from .util import is_multipart, serialize
 
 from .attachments import Attachments
+from .cells import Cells
 from .contacts import Contacts
 from .discussions import Discussions
 from .events import Events
@@ -119,6 +120,7 @@ class Smartsheet:
     """Use this to make requests to the Smartsheet API."""
 
     Attachments: Attachments
+    Cells: Cells
     Contacts: Contacts
     Discussions: Discussions
     Events: Events


### PR DESCRIPTION
# Pull Request

  ## Description
  Add `Cells` class to `Smartsheet` class for IDE autocomplete support. This change makes the `Cells` API accessible with proper type hints, enabling code completion in IDEs when accessing `smart.Cells` methods.

  ## Related Issue
  Fixes #121 

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [ ] Documentation update
  - [X] Code refactoring
  - [ ] Other (please describe):

  ## Environment Information
  - Smartsheet API Version: 2.0
  - Smartsheet Python SDK Version: 3.7.2
  - Python Version: 3.7+

  ## What Changes Were Made
  1. Added `from .cells import Cells` import in `smartsheet/smartsheet.py`
  2. Added `Cells: Cells` type annotation to the `Smartsheet` class
  3. Updated `CHANGELOG.md` with the new feature

  ## Why These Changes Were Made
  The `Cells` class was previously only accessible via the dynamic `__getattr__` method, which meant IDEs couldn't provide autocomplete for `Cells` methods like `get_cell_history()` and `add_image_to_cell()`. By
  adding explicit import and type annotation, developers now get proper IDE support, matching the pattern used for all other API resource classes (Sheets, Attachments, Contacts, etc.).

  ## Testing
  - [X] Ran existing test suite: `python -m pytest tests/`
  - [X] Ran pylint: `pylint smartsheet/smartsheet.py`
  - [X] Local test: added the local version to a python project that now I can see the `Cell` class from the LSP


  ## Checklist
  - [x] My code follows the [style guidelines](../../../CONTRIBUTING.md#code-style-and-quality) of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] I have updated the relevant files in `docs-source/` (no updates needed - autodoc handles this automatically)
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works (no new tests needed - this is a type annotation change)
  - [ ] New and existing unit tests pass locally with my changes

  ## Additional Notes
N/A