### PR TITLE
Add objectIdStr field to Event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [3.9.0] - 2026-04-22
+
+### Added
+
+- Added `object_id_str` field to Event model to support alphanumeric object identifiers in v2.0 events endpoint
+- Field is optional and maintains full backward compatibility with existing implementations
+
 ## [3.8.0] - 2026-04-17
 
 ### Added

--- a/smartsheet/models/event.py
+++ b/smartsheet/models/event.py
@@ -38,6 +38,7 @@ class Event:
         self._event_id = String()
         self._event_timestamp = None
         self._object_id = None
+        self._object_id_str = String()
         self._object_type = EnumeratedValue(EventObjectType)
         self._request_user_id = Number()
         self._source = EnumeratedValue(EventSource)
@@ -110,6 +111,14 @@ class Event:
     @object_id.setter
     def object_id(self, value):
         self._object_id = value
+
+    @property
+    def object_id_str(self):
+        return self._object_id_str.value
+
+    @object_id_str.setter
+    def object_id_str(self, value):
+        self._object_id_str.value = value
 
     @property
     def object_type(self):


### PR DESCRIPTION
## Summary
Adds the `object_id_str` field to the Event model to support alphanumeric object identifiers from the Smartsheet Events API v2.0 endpoint.

## Changes
- ✅ Added `_object_id_str = String()` field to Event model
- ✅ Added `object_id_str` property (getter/setter)
- ✅ Updated CHANGELOG.md with v3.9.0 entry
- ✅ Field is optional and backward compatible

## Testing
```python
# Test with objectIdStr
event = Event({"eventId": "test", "objectId": 123, "objectIdStr": "abc-123"})
assert event.object_id_str == "abc-123"

# Test without objectIdStr (backward compatibility)  
event = Event({"eventId": "test", "objectId": 456})
assert event.object_id_str is None
```

## Checklist
- [x] Code changes complete
- [x] CHANGELOG updated
- [ ] Unit tests added
- [ ] All tests passing
- [ ] Code review completed