### PR TITLE
Fix packaging after upgrading to uv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ docs-source/smartsheet*.rst
 .claude/settings.local.json
 # Superpowers documentation
 docs/superpowers
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.0.1] - 2026-06-09
+
+### Fixed
+
+- Packaging bug after migrating to uv. [#144](https://github.com/smartsheet/smartsheet-python-sdk/issues/144)
+
 ## [4.0.0] - 2026-06-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,12 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "smartsheet/version.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["smartsheet"]
+
+[tool.hatch.build.targets.sdist]
+include = ["smartsheet"]
+
 [project]
 name = "smartsheet-python-sdk"
 description = "Library that uses Python to connect to Smartsheet services (using API 2.0)."


### PR DESCRIPTION
# Pull Request

## Description

After the migration to uv, a packaging bug excluded the actual smartsheet package from the build.

Resolves #144 