### PR TITLE
Prepare for release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.1.0] - 2026-06-26
+
 ### Fixed
 
 - Added missing `SHARED` value to `PublishAccessibleBy` enum.


### PR DESCRIPTION
## Summary

Release prep for v4.1.0 (minor — all changes additive). Stamps the CHANGELOG `Unreleased` section with `## [4.1.0] - 2026-06-26`. No version-file edit — the package version is derived from the git tag (VCS-based versioning).

Released content accumulated on `mainline` since v4.0.2:
- **Added:** GET path endpoints (`get_sheet_path`, `get_report_path`, `get_sight_path`, `get_folder_path`) with `get_leaf_<asset>()` / `get_leaf_<asset>_path()` helpers.
- **Fixed:** Added missing `SHARED` value to `PublishAccessibleBy` enum.

## Test plan
- [ ] CI build + tests pass on the release branch