### PR TITLE
Prepare for release v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.2.0] - 2026-07-09
+
 ### Added
 
 - Support for GET /2.0/reports/{reportId}/definition (Get Report Definition) via `Reports.get_report_definition`


### PR DESCRIPTION
Release prep for v4.2.0 (minor — all changes additive). Stamps the CHANGELOG Unreleased section with ## [4.2.0] - 2026-07-09. No version-file edit — the package version is derived from the git tag (VCS-based versioning).

Released content accumulated on mainline since v4.1.0:

Added:
- Support for GET /2.0/reports/{reportId}/definition (Get Report Definition) via `Reports.get_report_definition`
- Support for GET /2.0/reports/{reportId}/columns (List Report Columns) via `Reports.list_report_columns`
- Support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} (Get Report Column) via `Reports.get_report_column`
- Support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} (Update Report Column) via `Reports.update_report_column`
- Support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} (Delete Report Column) via `Reports.delete_report_column`
- Support for GET /2.0/reports/{reportId}/scope (List Report Scope) via `Reports.list_report_scope`

Deprecated:
- Deprecated `Event.object_id`; use `Event.object_id_str` instead. `object_id` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.