### PR TITLE
Prepare for release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.3.0] - 2026-07-20
+
 ### Added
 
 - Add case for a template resource_type in append_data method in PaginatedChildrenResult model


### PR DESCRIPTION
## Release v4.3.0

Closes out the changelog for the v4.3.0 release. Branched from clean `mainline` per `RELEASE.md`.

> No version file to bump — the package version is derived from the git tag at build time via `hatch-vcs`.

### Changed files
- `CHANGELOG.md` — inserted `## [4.3.0] - 2026-07-20` header below the permanent `Unreleased` placeholder

### Changelog (4.3.0)

**Added**
- Add case for a template resource_type in append_data method in PaginatedChildrenResult model
- Add `Proof` model and `ProofType` enum
- Add a proof field to the `Row` model
- Add serialization tests for the new model

### Next steps (per RELEASE.md, done by a human)
- [ ] CI passes on this PR
- [ ] Merge to `mainline`
- [ ] Draft & publish GitHub Release, tag `v4.3.0` (Create new tag on publish), generate release notes → sets version & triggers PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)