### PR TITLE
Document proofs include value for get_sheet

### DIFF
--- a/smartsheet/sheets.py
+++ b/smartsheet/sheets.py
@@ -476,7 +476,7 @@ class Sheets:
             include (list[str]): A comma-separated list of
                 optional elements to include in the response. Valid list
                 values: attachments, columnType, crossSheetReferences, discussions, filters,
-                filterDefinitions, format, objectValue, ownerInfo, rowPermalink,
+                filterDefinitions, format, objectValue, ownerInfo, proofs, rowPermalink,
                 rowWriterInfo (deprecated - use writerInfo), source, summary, writerInfo.
             exclude (str): Response will not include cells
                 that have never contained any data.


### PR DESCRIPTION
Adds `proofs` to the documented valid `include` values for `get_sheet`, completing the proofs work started in #159.

The `Proof` model, `Row.proof`, and the `get_report` docstring already listed `proofs` (shipped in #159); the `get_sheet` docstring was the remaining gap. `include` is passed through, so `include=['proofs']` already worked at runtime — this is a docs-only fix.

DEVECO-2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `Sheets.get_sheet` documentation to list `proofs` as a valid include option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->