### PR TITLE
Prepare for release v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [x.x.x] - Unreleased
 
+## [4.4.0] - 2026-08-12
+
 ### Added
 
 - Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via `Users.list_user_plans`. The only accepted value is `planName`.


### PR DESCRIPTION
Closes out the CHANGELOG for v4.4.0. No version file to bump: the Python SDK derives its version from the git tag via `hatch-vcs`.

Minor bump: the Unreleased section contains non-breaking additions.

### Added

- Support for the `include` query parameter on GET /2.0/users/{userId}/plans (List User Plans) via `Users.list_user_plans`. The only accepted value is `planName`.
- Add a `plan_name` field to the `UserPlan` model, populated when `include=planName` is requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 4.4.0, dated August 12, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->